### PR TITLE
AndroidManifest has invalid XML

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
                 android:value="com.iukonline.amule.android.amuleremote.dlqueue.DlQueueActivity" />
         </activity>
         <activity
-            android:name=".search.SearchDetailsActivity">
+            android:name=".search.SearchDetailsActivity"
             android:parentActivityName=".search.SearchActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"


### PR DESCRIPTION
Because of this invalid XML android studio did not want to build

After this change I could build a APK and tested it. Setting the server version to 2.3.1 made it work with my 2.3.2 server.

Thanks for the work!